### PR TITLE
NTupler: Add calculation of HT from LHE-level MC truth

### DIFF
--- a/PATNTupler/plugins/RALMiniAnalyzer.cc
+++ b/PATNTupler/plugins/RALMiniAnalyzer.cc
@@ -67,6 +67,10 @@
 #include "SHarper/HEEPAnalyzer/interface/HEEPEleSelector.h"
 #include "SHarper/HEEPAnalyzer/interface/HEEPEvent.h"
 
+//... for accessing generator information (GenEventInfoProduct & LHE)
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+
 //...for histograms creation
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -110,6 +114,9 @@ class RALMiniAnalyzer : public edm::EDAnalyzer {
       ///For reading the event information into the member variables...
       void ReadInEvtInfo(bool, const edm::Event&);
 
+      ///For reading the LHE information, and dumping it into ran::Event class ...
+      void ReadInLheInfo(const edm::Event&);
+
       ///For reading in the electron information, and dumping it into ran::Event class ...
       void ReadInElectrons(const edm::Event&);
   
@@ -130,6 +137,8 @@ class RALMiniAnalyzer : public edm::EDAnalyzer {
       // ----------member data ---------------------------
 
       bool isMC_;
+      const bool ignoreTopInLheHtCalculation_;
+      edm::EDGetTokenT<LHEEventProduct> lheToken_;
       edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
       edm::EDGetTokenT<pat::MuonCollection> muonToken_;
       edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
@@ -182,6 +191,8 @@ class RALMiniAnalyzer : public edm::EDAnalyzer {
 RALMiniAnalyzer::RALMiniAnalyzer(const edm::ParameterSet& iConfig):
    //now do what ever initialization is needed
     isMC_(iConfig.getParameter<bool>("isThisMC")),
+    ignoreTopInLheHtCalculation_(iConfig.getParameter<bool>("ignoreTopInLheHtCalculation")),
+    lheToken_(consumes<LHEEventProduct>(iConfig.getParameter<edm::InputTag>("lhe"))),
     vtxToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertices"))),
     muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
     electronToken_(consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>("electrons"))),
@@ -258,6 +269,7 @@ RALMiniAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
    //  std::cout << "Trigger i (int): " << int(recordedTriggers_->at(i)) << " \n";
    //}
 
+
    //if (triggerOfInterest || isMC_){
      electronCollection_ = new std::vector<ran::ElectronStruct>();
      muonCollection_ = new std::vector<ran::MuonStruct>();
@@ -270,6 +282,9 @@ RALMiniAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 
      //Reading in the event information...
      ReadInEvtInfo(vBool_, iEvent);     
+
+     // Read in LHE event product (if present)
+     ReadInLheInfo(iEvent);
 
      //Read in muons
      ReadInMuons(iEvent);
@@ -441,6 +456,46 @@ void RALMiniAnalyzer::ReadInEvtInfo(bool beVerbose, const edm::Event& edmEventOb
       evtInfo.evtNum = edmEventObject.id().event(); 
 
 }
+
+
+void RALMiniAnalyzer::ReadInLheInfo(const edm::Event& iEvent)
+{
+  edm::Handle<LHEEventProduct> lheEventHandle;
+  iEvent.getByToken(lheToken_, lheEventHandle);
+
+  if( !(lheEventHandle.failedToGet()) ){
+
+    float ht = 0.0;
+    const lhef::HEPEUP eventInfo = lheEventHandle->hepeup();
+
+    // Now, loop over the particles in the LHE event ...
+    int numParticles = eventInfo.NUP;
+    for(int idx=0; idx<numParticles; idx++){
+      const int pdgId = eventInfo.IDUP.at(idx);
+      const int status = eventInfo.ISTUP.at(idx);
+      const std::pair<int, int> parents = eventInfo.MOTHUP.at(idx);
+      const int parent1pdgId = parents.first == 0 ? 0 : eventInfo.IDUP.at(parents.first - 1);
+      const int parent2pdgId = parents.second == 0 ? 0 : eventInfo.IDUP.at(parents.second - 1);
+      const double pT = sqrt(eventInfo.PUP.at(idx)[0]*eventInfo.PUP.at(idx)[0] + eventInfo.PUP.at(idx)[1]*eventInfo.PUP.at(idx)[1]);
+
+      // Calculating HT: Scalar sum of pT of ...
+      //   - quarks & gluons from the final state
+      //   - excluding particles that come from decay of top or W - at least for certain ttbar samples
+      // According to https://hypernews.cern.ch/HyperNews/CMS/get/generators/3367/1.html
+      if (status == 1 ) {
+        if (!ignoreTopInLheHtCalculation_)
+          ht += pT;
+        else if (((pdgId > 0 && pdgId < 6) || pdgId == 21) && parent1pdgId != 6 && parent2pdgId != 6 && parent1pdgId != 24 && parent2pdgId != 24
+                 && parent1pdgId != 23 && parent2pdgId != 23 && parent1pdgId != 25 && parent2pdgId != 25)
+          ht += pT;
+      }
+
+    } //END: for idx<numParticles
+  }
+  else 
+    std::cout << " ERROR : Couldn't find any LHE information" << std::endl;
+}
+
 
 void RALMiniAnalyzer::ReadInElectrons(const edm::Event& iEvent)
 {

--- a/PATNTupler/plugins/nTupleProduction.py
+++ b/PATNTupler/plugins/nTupleProduction.py
@@ -61,6 +61,7 @@ for idmod in my_id_modules:
 process.demo = cms.EDAnalyzer("RALMiniAnalyzer",
                                        isThisMC = cms.bool(True),
                                        #mcWeight = cms.double(MCWEIGHT_INSERTEDHERE),
+                                       containsLHE = cms.bool(True),
                                        lhe = cms.InputTag("externalLHEProducer"),
                                        ignoreTopInLheHtCalculation = cms.bool(True),
                                        heepId = cms.InputTag("heepId"),

--- a/PATNTupler/plugins/nTupleProduction.py
+++ b/PATNTupler/plugins/nTupleProduction.py
@@ -61,6 +61,8 @@ for idmod in my_id_modules:
 process.demo = cms.EDAnalyzer("RALMiniAnalyzer",
                                        isThisMC = cms.bool(True),
                                        #mcWeight = cms.double(MCWEIGHT_INSERTEDHERE),
+                                       lhe = cms.InputTag("externalLHEProducer"),
+                                       ignoreTopInLheHtCalculation = cms.bool(True),
                                        heepId = cms.InputTag("heepId"),
                                        vertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
                                        muons = cms.InputTag("slimmedMuons"),


### PR DESCRIPTION
This pull request contains the changes required for calculating HT from the LHE-level MC truth information, and storing it as a single branch, of name `lheHT`, at the top of the output NTuple

3 new parameters are exposed in the NTupler's Python configuration:
 * `containsLHE` (bool):
   * If `true`, LHE information is read from the input file, and stored in the output NTuple.
   * If `false`,  LHE information is *not* read from the input file, and the output NTuple doesn't contain the `lheHT` branch
 * `lhe`: Input tag specifying which LHE collection should be used
 * `ignoreTopInLheHtCalculation` (bool)
   * If `true`, HT = sum of pT of final-state quarks and gluons that are not children of a top quark/antiquark, a W boson, a Z boson or a Higgs boson
   * If `false`, HT = sum of pT of all final-state particles
   * In general, should be set to `true` for ttbar samples whose generation involved `MadSpin`, and set to `false` otherwise